### PR TITLE
Get rid of an unused method

### DIFF
--- a/Example/Example/PBExampleViewController.m
+++ b/Example/Example/PBExampleViewController.m
@@ -37,10 +37,6 @@ static NSString *kCellIdentifier = @"CellIdentifier";
     return cell;
 }
 
-- (NSArray *)currentlyVisibleItems {
-    return [self itemsForPage:self.collectionViewController.currentPage];
-}
-
 #pragma PBGSDataSource
 
 - (NSArray *)itemsForPage:(NSInteger)page {


### PR DESCRIPTION
Unused code causes brain damage.
